### PR TITLE
dep:tokio-websocekts 0.11 => 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ futures-util = { version = "0.3", features = ["sink"] }
 http = "1"
 hyper = "1"
 hyper-util = { version = "0.1", features = ["tokio"] }
-sha1 = "0.10"
+sha1_smol = "1.0"
 tokio = { version = "1", default-features = false }
 tokio-websockets = { version = "0.13.1", features = ["server", "sha1_smol"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ hyper = "1"
 hyper-util = { version = "0.1", features = ["tokio"] }
 sha1 = "0.10"
 tokio = { version = "1", default-features = false }
-tokio-websockets = { version = "0.11", features = ["server", "ring"] }
+tokio-websockets = { version = "0.13.1", features = ["server", "sha1_smol"] }
 
 [dev-dependencies]
 axum = { version = "0.8", features = ["ws"] }


### PR DESCRIPTION
Updates `tokio-websockets` to 0.13.

Changes `tokio-websockets` to use `sha1_smol` instead of `ring`.

Changes `axum-tws` to use `sha1_smol` instead of `sha1`.